### PR TITLE
refactor: unify frontend API base URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Smart Farm System is a full-stack application for managing farm operations. The 
 ## Frontend Setup
 1. `cd frontend`
 2. `npm install`
-3. `npm run dev` to launch the Vite dev server
+3. Create a `.env` file with the variables listed below
+4. `npm run dev` to launch the Vite dev server
 
 ### Frontend Environment Variables
 | Variable | Description |

--- a/frontend/src/pages/livestock/Health.jsx
+++ b/frontend/src/pages/livestock/Health.jsx
@@ -8,7 +8,7 @@ import {
 } from "./HealthModals";
 
 /* ================== Config ================== */
-const API = import.meta.env.VITE_API_URL || "http://localhost:5001";
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:5001";
 const DAYS_WINDOW = 180;
 
 /* ================== Utils ================== */

--- a/frontend/src/pages/livestock/HealthModals.jsx
+++ b/frontend/src/pages/livestock/HealthModals.jsx
@@ -1,7 +1,7 @@
 // HealthModals.jsx (Updated and Fixed Code)
 import React, { useEffect, useState } from "react";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5001";
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:5001";
 const pad = (n) => String(n).padStart(2, "0");
 const liso = (d) => { 
   if (!d) return "";

--- a/frontend/src/pages/livestock/Milk.jsx
+++ b/frontend/src/pages/livestock/Milk.jsx
@@ -12,7 +12,7 @@ import { FaDownload, FaPlus, FaSearch } from "react-icons/fa";
 import { createPortal } from "react-dom";
 import { AddRecordModal, EditRecordModal } from "./MilkModal";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5001";
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:5001";
 
 /* ---------- date helpers ---------- */
 const pad = (n) => String(n).padStart(2, "0");

--- a/frontend/src/pages/livestock/MilkModal.jsx
+++ b/frontend/src/pages/livestock/MilkModal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5001";
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:5001";
 const todayKey = () => {
   const d = new Date();
   d.setHours(0, 0, 0, 0);

--- a/frontend/src/pages/livestock/cow.jsx
+++ b/frontend/src/pages/livestock/cow.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { FaPlus, FaSearch, FaEllipsisV } from "react-icons/fa";
 import { ActionsMenuPortal, CowFormModal, ViewCowModal  } from "./CowModals";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5001";
+const API = import.meta.env.VITE_API_BASE_URL || "http://localhost:5001";
 
 const StatusPill = ({ children, tone = "active" }) => (
   <span


### PR DESCRIPTION
## Summary
- replace `VITE_API_URL` with `VITE_API_BASE_URL` across livestock pages
- clarify frontend setup to create an `.env` with `VITE_API_BASE_URL`

## Testing
- `npm test` *(fails: Cannot find package 'jsdom'; install attempt blocked with 403)*
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a463132858832197f16ce284bb71cf