### PR TITLE
Enable payroll slip filtering by month and year

### DIFF
--- a/backend/routes/payroll.routes.js
+++ b/backend/routes/payroll.routes.js
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import {
+  listPaymentSlips,
   previewPayroll,
   commitPayroll,
 } from "../controllers/payroll.controller.js";
 const router = Router();
 
+router.get("/", listPaymentSlips);
 router.post("/preview", previewPayroll); // calculate & store draft
 router.post("/commit", commitPayroll); // save to PaymentSlip
 

--- a/frontend/src/admin/FinancePayrollManagement.jsx
+++ b/frontend/src/admin/FinancePayrollManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Play, Save, Calendar, Users, DollarSign, Loader2 } from "lucide-react";
 import { api } from "../lib/api";
 
@@ -7,6 +7,18 @@ const money = (n) =>
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
+
+const MONTH_NAMES = Array.from({ length: 12 }, (_, i) =>
+  new Date(2000, i, 1).toLocaleDateString("en", { month: "long" })
+);
+
+const getMonthName = (value) => {
+  const monthNumber = Number(value);
+  if (!Number.isFinite(monthNumber)) return "—";
+  const index = monthNumber - 1;
+  if (index < 0 || index >= MONTH_NAMES.length) return "—";
+  return MONTH_NAMES[index];
+};
 
 const STATUS_STYLES = {
   PENDING: {
@@ -21,7 +33,38 @@ const STATUS_STYLES = {
     label: "Saved",
     className: "bg-blue-100 text-blue-800",
   },
+  PAID: {
+    label: "Paid",
+    className: "bg-emerald-100 text-emerald-700",
+  },
+  CANCELLED: {
+    label: "Cancelled",
+    className: "bg-red-100 text-red-600",
+  },
 };
+
+const mapEmployeeToRow = (employee, month, year) => ({
+  employee: {
+    id: employee._id || employee.id,
+    empId:
+      employee.empId ||
+      (employee._id ? String(employee._id).slice(-6) : "Unknown"),
+    name: employee.name || "Unknown",
+  },
+  month,
+  year: year ?? null,
+  basicSalary: Number(employee.basicSalary) || 0,
+  workingHours: Number(employee.workingHours) || 0,
+  allowances: Number(employee.allowances ?? employee.allowance ?? 0),
+  loan: Number(employee.loan ?? 0),
+  otTotal: null,
+  epf: null,
+  etf: null,
+  gross: null,
+  netSalary: null,
+  status: "PENDING",
+  updatedAt: null,
+});
 
 // quick UUID for draftKey (browser-only ok)
 const uuid = () => crypto.randomUUID?.() || Math.random().toString(36).slice(2);
@@ -31,6 +74,8 @@ export default function PayrollRunPage() {
   const [month, setMonth] = useState(today.getMonth() + 1);
   const [year, setYear] = useState(today.getFullYear());
 
+  const [employees, setEmployees] = useState([]);
+  const [loadingEmployees, setLoadingEmployees] = useState(true);
   const [rows, setRows] = useState([]);
   const [draftId, setDraftId] = useState(null);
   const [draftKey] = useState(uuid);
@@ -39,47 +84,181 @@ export default function PayrollRunPage() {
   const [calculating, setCalculating] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  // 1) Load employees (pre-calc)
+  const isYearValid =
+    Number.isInteger(year) && year >= 2020 && year <= 2035;
+
+  // 1) Load employees (pre-calc source data)
   useEffect(() => {
-    let mounted = true;
+    let active = true;
     (async () => {
       try {
         const res = await api.get("/employees/min");
         const emps = Array.isArray(res.data) ? res.data : [];
-        mounted &&
-          setRows(
-            emps.map((e) => ({
-              // pre-calc visible fields
-              employee: { id: e._id, empId: e.empId, name: e.name },
-              basicSalary: Number(e.basicSalary) || 0,
-              workingHours: Number(e.workingHours) || 0,
-              allowances: Number(e.allowances) || 0,
-              loan: Number(e.loan) || 0,
-
-              // computed (empty until preview)
-              otTotal: null,
-              epf: null,
-              etf: null,
-              gross: null,
-              netSalary: null,
-              status: "PENDING",
-              updatedAt: null,
-            }))
-          );
-        setDraftId(null);
+        if (active) {
+          setEmployees(emps);
+        }
+      } catch (err) {
+        console.error("Failed to load employees", err);
+        if (active) {
+          setEmployees([]);
+        }
       } finally {
-        mounted && setLoading(false);
+        active && setLoadingEmployees(false);
       }
     })();
-    return () => (mounted = false);
+    return () => {
+      active = false;
+    };
   }, []);
+
+  const loadSlips = useCallback(
+    async (selectedMonth, selectedYear) => {
+      setLoading(true);
+      try {
+        const params = {};
+        if (
+          Number.isInteger(selectedMonth) &&
+          selectedMonth >= 1 &&
+          selectedMonth <= 12
+        ) {
+          params.month = selectedMonth;
+        }
+        if (
+          Number.isInteger(selectedYear) &&
+          selectedYear >= 1900 &&
+          selectedYear <= 3000
+        ) {
+          params.year = selectedYear;
+        }
+
+        const res = await api.get("/payrolls", { params });
+        const slips = Array.isArray(res.data) ? res.data : [];
+
+        const slipRows = slips.map((slip) => {
+          const employee = slip.employee || {};
+          const employeeId = employee.id || employee._id || null;
+
+          return {
+            employee: {
+              id: employeeId,
+              empId:
+                employee.empId ||
+                (employeeId ? String(employeeId).slice(-6) : "Unknown"),
+              name: employee.name || "Unknown",
+            },
+            month:
+              slip.month != null
+                ? Number(slip.month)
+                : selectedMonth ?? null,
+            year:
+              slip.year != null
+                ? Number(slip.year)
+                : selectedYear ?? null,
+            basicSalary: Number(slip.basicSalary) || 0,
+            workingHours: Number(slip.workingHours) || 0,
+            allowances: Number(slip.allowances ?? 0),
+            loan: Number(slip.loan ?? 0),
+            otTotal:
+              slip.otTotal === null || slip.otTotal === undefined
+                ? null
+                : Number(slip.otTotal),
+            epf:
+              slip.epf === null || slip.epf === undefined
+                ? null
+                : Number(slip.epf),
+            etf:
+              slip.etf === null || slip.etf === undefined
+                ? null
+                : Number(slip.etf),
+            gross:
+              slip.gross === null || slip.gross === undefined
+                ? null
+                : Number(slip.gross),
+            netSalary:
+              slip.netSalary === null || slip.netSalary === undefined
+                ? null
+                : Number(slip.netSalary),
+            status: String(slip.status || "PENDING").toUpperCase(),
+            updatedAt: slip.updatedAt || null,
+          };
+        });
+
+        if (slipRows.length > 0) {
+          if (employees.length > 0) {
+            const slipByEmployee = new Map();
+            const orphanRows = [];
+
+            slipRows.forEach((row) => {
+              const key = row.employee?.id;
+              if (key) {
+                slipByEmployee.set(String(key), row);
+              } else {
+                orphanRows.push(row);
+              }
+            });
+
+            const merged = employees.map((emp) => {
+              const empId = emp._id || emp.id;
+              const key = empId ? String(empId) : null;
+              if (key && slipByEmployee.has(key)) {
+                const row = slipByEmployee.get(key);
+                slipByEmployee.delete(key);
+                return row;
+              }
+              return mapEmployeeToRow(emp, selectedMonth, selectedYear);
+            });
+
+            const remaining = Array.from(slipByEmployee.values());
+            setRows([...merged, ...remaining, ...orphanRows]);
+          } else {
+            setRows(slipRows);
+          }
+        } else {
+          setRows(
+            employees.map((emp) =>
+              mapEmployeeToRow(emp, selectedMonth, selectedYear)
+            )
+          );
+        }
+        setDraftId(null);
+      } catch (err) {
+        console.error("Failed to load payment slips", err);
+        setRows(
+          employees.map((emp) =>
+            mapEmployeeToRow(emp, selectedMonth, selectedYear)
+          )
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [employees]
+  );
+
+  useEffect(() => {
+    if (loadingEmployees) return;
+
+    if (!isYearValid) {
+      setDraftId(null);
+      setRows(
+        employees.map((emp) => mapEmployeeToRow(emp, month, null))
+      );
+      setLoading(false);
+      return;
+    }
+
+    loadSlips(month, year);
+  }, [employees, isYearValid, loadSlips, loadingEmployees, month, year]);
 
   // 2) Calculate (backend preview → draft)
   async function handleCalculateAll() {
-    if (rows.length === 0) return;
+    if (!isYearValid) return;
+    const employeeIds = rows
+      .map((r) => r.employee.id)
+      .filter(Boolean);
+    if (employeeIds.length === 0) return;
     setCalculating(true);
     try {
-      const employeeIds = rows.map((r) => r.employee.id);
       const res = await api.post("/payrolls/preview", {
         draftKey,
         month,
@@ -92,11 +271,37 @@ export default function PayrollRunPage() {
       // server returns computed items: map to UI rows
       setRows(
         items.map((it) => ({
-          ...it,
-          // normalize field names
-          gross: it.gross,
-          netSalary: it.net,
+          employee: {
+            id: it.employee?.id || it.employee?._id || null,
+            empId:
+              it.employee?.empId ||
+              (it.employee?.id
+                ? String(it.employee.id).slice(-6)
+                : "Unknown"),
+            name: it.employee?.name || "Unknown",
+          },
+          month,
+          year,
+          basicSalary: Number(it.basicSalary) || 0,
+          workingHours: Number(it.workingHours) || 0,
+          allowances: Number(it.allowances ?? 0),
+          loan: Number(it.loan ?? 0),
+          otTotal:
+            it.otTotal === null || it.otTotal === undefined
+              ? null
+              : Number(it.otTotal),
+          epf:
+            it.epf === null || it.epf === undefined ? null : Number(it.epf),
+          etf:
+            it.etf === null || it.etf === undefined ? null : Number(it.etf),
+          gross:
+            it.gross === null || it.gross === undefined
+              ? null
+              : Number(it.gross),
+          netSalary:
+            it.net === null || it.net === undefined ? null : Number(it.net),
           status: "READY",
+          updatedAt: null,
         }))
       );
     } finally {
@@ -106,22 +311,11 @@ export default function PayrollRunPage() {
 
   // 3) Commit (save to PaymentSlip)
   async function handleSaveAll() {
-    if (!draftId) return;
+    if (!draftId || !isYearValid) return;
     setSaving(true);
     try {
       await api.post("/payrolls/commit", { draftId });
-      // Optionally: keep draftId (null to prevent double-save)
-      setDraftId(null);
-      setRows((prev) =>
-        prev.map((row) =>
-          row.netSalary != null
-            ? {
-                ...row,
-                status: "SAVED",
-              }
-            : row
-        )
-      );
+      await loadSlips(month, year);
     } finally {
       setSaving(false);
     }
@@ -148,11 +342,9 @@ export default function PayrollRunPage() {
                 value={month}
                 onChange={(e) => setMonth(Number(e.target.value))}
               >
-                {Array.from({ length: 12 }, (_, i) => (
-                  <option key={i + 1} value={i + 1}>
-                    {new Date(2023, i, 1).toLocaleDateString("en", {
-                      month: "long",
-                    })}
+                {MONTH_NAMES.map((label, index) => (
+                  <option key={index + 1} value={index + 1}>
+                    {label}
                   </option>
                 ))}
               </select>
@@ -160,7 +352,10 @@ export default function PayrollRunPage() {
                 type="number"
                 className="border rounded-lg px-3 py-2 w-24 text-sm"
                 value={year}
-                onChange={(e) => setYear(Number(e.target.value))}
+                onChange={(e) => {
+                  if (e.target.value === "") return;
+                  setYear(Number(e.target.value));
+                }}
                 min="2020"
                 max="2035"
               />
@@ -169,7 +364,9 @@ export default function PayrollRunPage() {
             <div className="flex gap-2">
               <button
                 onClick={handleCalculateAll}
-                disabled={calculating || rows.length === 0}
+                disabled={
+                  calculating || rows.length === 0 || !isYearValid
+                }
                 className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-400 text-white rounded-lg text-sm"
               >
                 {calculating ? (
@@ -182,7 +379,7 @@ export default function PayrollRunPage() {
 
               <button
                 onClick={handleSaveAll}
-                disabled={saving || !draftId}
+                disabled={saving || !draftId || !isYearValid}
                 className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg text-sm"
               >
                 {saving ? (
@@ -224,6 +421,8 @@ export default function PayrollRunPage() {
               <tr>
                 {[
                   "Employee",
+                  "Month",
+                  "Year",
                   "Basic Salary",
                   "Working Hours",
                   "Allowances",
@@ -250,7 +449,7 @@ export default function PayrollRunPage() {
                   STATUS_STYLES[row.status] || STATUS_STYLES.PENDING;
                 return (
                   <tr
-                    key={`${row.employee.id || row.employee._id}-${idx}`}
+                    key={`${row.employee.id ?? "row"}-${idx}`}
                     className="hover:bg-gray-50"
                   >
                     <td className="px-4 py-3">
@@ -258,6 +457,13 @@ export default function PayrollRunPage() {
                       <div className="text-sm text-gray-500">
                         {row.employee.empId}
                       </div>
+                    </td>
+
+                    <td className="px-4 py-3 text-right">
+                      {row.month ? getMonthName(row.month) : "—"}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {row.year != null ? row.year : "—"}
                     </td>
 
                     <td className="px-4 py-3 text-right font-medium">


### PR DESCRIPTION
## Summary
- add a backend controller and route to list payment slips filtered by month and year with normalized employee details
- update the payroll management page to load saved slips per period, merge with employee records, and show month/year columns alongside totals
- refresh status handling and reload the table from the server after saving payroll drafts

## Testing
- npm run lint *(fails: existing unused-variable and hook dependency warnings across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cda7f71aa88321847840e4aa09b60f