### PR TITLE
Export finance transactions as downloadable PDF

### DIFF
--- a/frontend/src/admin/FinanceTransaction.jsx
+++ b/frontend/src/admin/FinanceTransaction.jsx
@@ -1,8 +1,13 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../lib/api";
-import { useReactToPrint } from "react-to-print";
-import { InvoiceTemplate } from "../components/common/InvoiceTemplate";
+import jsPDF from "jspdf";
+import autoTable from "jspdf-autotable";
+import {
+  BRAND_CONTACT_LINE,
+  BRAND_DETAILS,
+  BRAND_DOCUMENT_TITLES,
+} from "../constants/branding";
 
 function currency(n) {
   if (isNaN(n)) return "—";
@@ -83,6 +88,32 @@ function shortDate(d) {
   }
 }
 
+function resolveRowId(row) {
+  if (!row) return undefined;
+
+  const candidates = [
+    row.mongoId,
+    row._id,
+    row.id,
+    row.transaction_id,
+    row.transactionId,
+    row.tid,
+    row.txnId,
+    row.txn_id,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+    if (typeof candidate === "number") {
+      return String(candidate);
+    }
+  }
+
+  return undefined;
+}
+
 export default function FinanceTransaction() {
   const [transactions, setTransactions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -94,7 +125,6 @@ export default function FinanceTransaction() {
   const [showDeleteModal, setShowDeleteModal] = useState(null); // stores mongoId or txnId
 
   const navigate = useNavigate();
-  const invoiceRef = useRef(null);
 
   useEffect(() => {
     let ignore = false;
@@ -174,57 +204,157 @@ export default function FinanceTransaction() {
     return `Transaction-${year}-${month}`;
   }, [exportDate]);
 
-  const pdfOrder = useMemo(() => {
-    if (!filtered.length) return null;
-
-    const items = filtered.map((txn) => {
-      const amountRaw = Number(txn.amount) || 0;
-      const amount = txn.type === "EXPENSE" ? -Math.abs(amountRaw) : Math.abs(amountRaw);
-      return {
-        name: `${shortDate(txn.date)} • ${txn.type || "Transaction"} • ${txn.category || "General"}`,
-        qty: 1,
-        price: amount,
-      };
-    });
-
-    const totalPrice = items.reduce(
-      (sum, item) => sum + item.price * (item.qty || 1),
-      0
-    );
-
-    return {
-      orderNumber: exportFileBase,
-      createdAt: exportDate,
-      status: "Approved",
-      paymentMethod: "Transactions",
-      customer: {
-        name: "Smart Farm Finance",
-        email: "finance@smartfarm.local",
-      },
-      shippingAddress: {
-        addressLine1: "Transaction Summary Report",
-        city: "",
-        postalCode: "",
-      },
-      orderItems: items,
-      totalPrice,
-      discount: { amount: 0 },
-    };
-  }, [filtered, exportDate, exportFileBase]);
-
-  const triggerPrint = useReactToPrint({
-    contentRef: invoiceRef,
-    documentTitle: exportFileBase,
-    removeAfterPrint: true,
-    suppressErrors: true,
-  });
+  const exportPeriodLabel = useMemo(() => {
+    if (monthFilter === "all") return "All Transactions";
+    const [year, month] = monthFilter.split("-");
+    const y = Number(year);
+    const m = Number(month) - 1;
+    if (!Number.isNaN(y) && !Number.isNaN(m) && m >= 0 && m < 12) {
+      const d = new Date(y, m, 1);
+      if (!Number.isNaN(d.getTime())) {
+        return d.toLocaleDateString(undefined, {
+          month: "long",
+          year: "numeric",
+        });
+      }
+    }
+    return monthFilter;
+  }, [monthFilter]);
 
   const handleExportPdf = () => {
-    if (!filtered.length || !pdfOrder) {
+    if (!filtered.length) {
       alert("No transactions to export.");
       return;
     }
-    triggerPrint?.();
+
+    const doc = new jsPDF({ orientation: "portrait", unit: "pt", format: "a4" });
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const marginX = 40;
+    const generatedAt = new Date();
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(20);
+    doc.setTextColor(22, 101, 52);
+    doc.text(BRAND_DETAILS.name, marginX, 40);
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+    doc.setTextColor(75, 85, 99);
+    doc.text(BRAND_DETAILS.address, marginX, 58);
+    doc.text(BRAND_CONTACT_LINE, marginX, 72);
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(16);
+    doc.setTextColor(75, 85, 99);
+    const headerTitle = `${BRAND_DOCUMENT_TITLES.report} - Transactions`;
+    doc.text(headerTitle, marginX, 102);
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+    doc.setTextColor(55, 65, 81);
+
+    const filterLines = [
+      `Period: ${exportPeriodLabel}`,
+      `Type: ${typeFilter === "all" ? "All Types" : typeFilter}`,
+    ];
+    if (q) {
+      filterLines.push(`Search: "${q}"`);
+    }
+    filterLines.forEach((line, index) => {
+      doc.text(line, marginX, 122 + index * 14);
+    });
+
+    doc.text(`Generated: ${generatedAt.toLocaleString()}`, pageWidth - marginX, 122, {
+      align: "right",
+    });
+
+    const filterBlockBottom = 122 + (filterLines.length - 1) * 14;
+    const tableStartY = filterLines.length ? filterBlockBottom + 20 : 150;
+
+    const tableBody = filtered.map((txn, idx) => {
+      const amountRaw = Number(txn.amount) || 0;
+      const normalizedAmount =
+        txn.type === "EXPENSE" ? -Math.abs(amountRaw) : Math.abs(amountRaw);
+      return [
+        txn.transaction_id || `TX-${idx + 1}`,
+        shortDate(txn.date),
+        txn.type || "—",
+        txn.category || "—",
+        txn.description || "—",
+        currency(normalizedAmount),
+      ];
+    });
+
+    autoTable(doc, {
+      startY: tableStartY,
+      head: [
+        [
+          "Transaction ID",
+          "Date",
+          "Type",
+          "Category",
+          "Description",
+          "Amount",
+        ],
+      ],
+      body: tableBody,
+      styles: {
+        fontSize: 9,
+        cellPadding: 6,
+        textColor: [55, 65, 81],
+      },
+      headStyles: {
+        fillColor: [240, 253, 244],
+        textColor: [22, 101, 52],
+        lineWidth: 0.3,
+        lineColor: [209, 250, 229],
+      },
+      alternateRowStyles: {
+        fillColor: [248, 250, 252],
+      },
+      columnStyles: {
+        1: { halign: "center" },
+        5: { halign: "right" },
+      },
+      bodyStyles: {
+        valign: "middle",
+      },
+    });
+
+    const totals = filtered.reduce(
+      (acc, txn) => {
+        const amountRaw = Math.abs(Number(txn.amount) || 0);
+        if (txn.type === "EXPENSE") {
+          acc.expense += amountRaw;
+          acc.net -= amountRaw;
+        } else {
+          acc.income += amountRaw;
+          acc.net += amountRaw;
+        }
+        return acc;
+      },
+      { income: 0, expense: 0, net: 0 }
+    );
+
+    const finalY = doc.lastAutoTable?.finalY || tableStartY;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(12);
+    doc.setTextColor(22, 101, 52);
+    doc.text(`Net Total: ${currency(totals.net)}`, pageWidth - marginX, finalY + 26, {
+      align: "right",
+    });
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(10);
+    doc.setTextColor(75, 85, 99);
+    doc.text(`Income: ${currency(totals.income)}`, pageWidth - marginX, finalY + 42, {
+      align: "right",
+    });
+    doc.text(`Expenses: ${currency(-totals.expense)}`, pageWidth - marginX, finalY + 56, {
+      align: "right",
+    });
+
+    doc.save(`${exportFileBase}.pdf`);
   };
 
   const handleExportExcel = () => {
@@ -694,9 +824,6 @@ export default function FinanceTransaction() {
             </div>
           )}
         </div>
-      </div>
-      <div className="hidden">
-        {pdfOrder && <InvoiceTemplate ref={invoiceRef} order={pdfOrder} />}
       </div>
     </div>
   );

--- a/frontend/src/components/common/InvoiceTemplate.jsx
+++ b/frontend/src/components/common/InvoiceTemplate.jsx
@@ -25,6 +25,49 @@ export const InvoiceTemplate = forwardRef(function InvoiceTemplate({ order }, re
   const customer = order?.customer || {};
   const shipping = order?.shippingAddress || {};
   const items = Array.isArray(order?.orderItems) ? order.orderItems : [];
+  const templateOptions = order?.templateOptions || {};
+
+  const showBillingDetails =
+    templateOptions.showBillingDetails ?? templateOptions.showCustomerSection ?? true;
+  const showOrderSummary =
+    templateOptions.showOrderSummary ?? templateOptions.showMetaSummary ?? true;
+  const showFooter = templateOptions.showFooter ?? true;
+  const footerLines = Array.isArray(templateOptions.footerLines)
+    ? templateOptions.footerLines
+    : [
+        "Thank you for your business!",
+        "If you have any questions about this invoice, please contact us.",
+      ];
+
+  const billingSection =
+    showBillingDetails && (
+      <div>
+        <h3 className="font-semibold mb-1">Bill To:</h3>
+        <p>{customer.name || "—"}</p>
+        <p>{shipping.addressLine1 || "—"}</p>
+        <p>
+          {shipping.city || "—"}
+          {shipping.postalCode ? `, ${shipping.postalCode}` : ""}
+        </p>
+        <p>{customer.email || "—"}</p>
+      </div>
+    );
+
+  const summarySection =
+    showOrderSummary && (
+      <div
+        className={`text-right ${
+          billingSection ? "" : "col-span-2 md:col-span-1"
+        }`}
+      >
+        <p className="font-semibold">
+          Order Status: <span className="font-normal">{order?.status || "—"}</span>
+        </p>
+        <p className="font-semibold">
+          Payment Method: <span className="font-normal">{order?.paymentMethod || "Stripe (Card)"}</span>
+        </p>
+      </div>
+    );
 
   return (
     <div ref={ref} className="p-8 bg-white text-gray-800">
@@ -45,26 +88,16 @@ export const InvoiceTemplate = forwardRef(function InvoiceTemplate({ order }, re
       </header>
 
       {/* Customer / Meta */}
-      <section className="grid grid-cols-2 gap-8 my-8">
-        <div>
-          <h3 className="font-semibold mb-1">Bill To:</h3>
-          <p>{customer.name || "—"}</p>
-          <p>{shipping.addressLine1 || "—"}</p>
-          <p>
-            {shipping.city || "—"}
-            {shipping.postalCode ? `, ${shipping.postalCode}` : ""}
-          </p>
-          <p>{customer.email || "—"}</p>
-        </div>
-        <div className="text-right">
-          <p className="font-semibold">
-            Order Status: <span className="font-normal">{order?.status || "—"}</span>
-          </p>
-          <p className="font-semibold">
-            Payment Method: <span className="font-normal">{order?.paymentMethod || "Stripe (Card)"}</span>
-          </p>
-        </div>
-      </section>
+      {(billingSection || summarySection) && (
+        <section
+          className={`grid gap-8 my-8 ${
+            billingSection && summarySection ? "grid-cols-2" : "grid-cols-1"
+          }`}
+        >
+          {billingSection}
+          {summarySection}
+        </section>
+      )}
 
       {/* Items */}
       <section>
@@ -130,10 +163,13 @@ export const InvoiceTemplate = forwardRef(function InvoiceTemplate({ order }, re
       </section>
 
       {/* Footer */}
-      <footer className="mt-12 text-center text-gray-500 text-sm">
-        <p>Thank you for your business!</p>
-        <p>If you have any questions about this invoice, please contact us.</p>
-      </footer>
+      {showFooter && (
+        <footer className="mt-12 text-center text-gray-500 text-sm">
+          {footerLines.map((line, idx) => (
+            <p key={idx}>{line}</p>
+          ))}
+        </footer>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- replace the react-to-print flow with a jsPDF export so the finance transaction report downloads as a PDF instead of opening the browser print dialog
- render branding, applied filters, tabular transaction data, and net/income/expense totals inside the generated PDF for a clear report layout

## Testing
- npx eslint src/admin/FinanceTransaction.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d37dc06fd88321988774a8b1306ccc