### PR TITLE
Add dedicated PDF templates for finance reports

### DIFF
--- a/frontend/src/admin/FinanceAuditLogPage.jsx
+++ b/frontend/src/admin/FinanceAuditLogPage.jsx
@@ -16,7 +16,7 @@ import {
 
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
-import { InvoiceTemplate } from "../components/common/InvoiceTemplate";
+import { AuditLogPdfTemplate } from "../components/reports/AuditLogPdfTemplate";
 
 /* ---------- Helpers ---------- */
 const formatDateTime = (iso) => {
@@ -271,7 +271,7 @@ export default function AuditLogPage() {
       alert("No audit logs to export.");
       return;
     }
-    if (!pdfOrder) {
+    if (!pdfReportData) {
       alert("Report not ready.");
       return;
     }
@@ -362,12 +362,11 @@ export default function AuditLogPage() {
     return filteredLogs.slice(start, start + pageSize);
   }, [filteredLogs, page]);
 
-  const pdfOrder = useMemo(() => {
+  const pdfReportData = useMemo(() => {
     if (!filteredLogs.length) return null;
 
     const generatedAt = new Date();
     const filterDateLabel = formatDateOnly(filters.date) || "All Dates";
-
     const transactionFilterLabel = filters.transactionId
       ? `Matching "${filters.transactionId}"`
       : "All Transactions";
@@ -394,10 +393,6 @@ export default function AuditLogPage() {
       ? (totalFieldChanges / filteredLogs.length).toFixed(1)
       : "0";
 
-    const actionBreakdown = Object.entries(actionCounts)
-      .map(([action, count]) => `${action}: ${count}`)
-      .join(" | ");
-
     const uniqueUsers = Array.from(
       new Set(filteredLogs.map((log) => log.user).filter(Boolean))
     );
@@ -409,232 +404,49 @@ export default function AuditLogPage() {
       return latest;
     }, null);
 
-    const summaryLines = [
-      {
-        label: "Report Generated",
-        value: formatDateTime(generatedAt.toISOString()),
-      },
-      {
-        label: "Filter Date",
-        value: filterDateLabel,
-      },
-      {
-        label: "Transaction Filter",
-        value: transactionFilterLabel,
-      },
-      {
-        label: "Total Records",
-        value: filteredLogs.length,
-      },
-    ];
-
-    if (collectionsImpacted.length) {
-      summaryLines.push({
-        label: `Collections Impacted (${collectionsImpacted.length})`,
-        value: collectionsImpacted.join(", "),
-      });
-    }
-
-    if (uniqueUsers.length) {
-      summaryLines.push({
-        label: `Users Involved (${uniqueUsers.length})`,
-        value: uniqueUsers.join(", "),
-      });
-    }
-
-    if (actionBreakdown) {
-      summaryLines.push({
-        label: "Action Breakdown",
-        value: actionBreakdown,
-      });
-    }
-
-    summaryLines.push({
-      label: "Total Field Changes",
-      value: totalFieldChanges,
-    });
-
-    summaryLines.push({
-      label: "Avg Fields Changed / Record",
-      value: averageFieldChanges,
-    });
-
-    if (latestTimestamp) {
-      summaryLines.push({
-        label: "Most Recent Activity",
-        value: formatDateTime(new Date(latestTimestamp).toISOString()),
-      });
-    }
-
-    const renderChangeColumn = (data, variant, diffs) => {
-      const isOriginal = variant === "original";
-      const headerClasses = isOriginal
-        ? "bg-red-100 text-red-700"
-        : "bg-emerald-100 text-emerald-700";
-      const borderClasses = isOriginal
-        ? "border-red-200"
-        : "border-emerald-200";
-
-      return (
-        <div className={`border ${borderClasses} rounded-md overflow-hidden`}>
-          <div
-            className={`${headerClasses} px-2 py-1 text-xs font-semibold uppercase`}
-          >
-            {isOriginal ? "Original Data" : "Updated Data"}
-          </div>
-          <div className="p-2">
-            <dl className="space-y-1">
-              {AUDIT_FIELDS.map(({ key, label }) => (
-                <div
-                  key={key}
-                  className={`grid grid-cols-2 gap-2 text-[11px] leading-snug rounded px-2 -mx-2 ${
-                    diffs[key]
-                      ? isOriginal
-                        ? "bg-amber-50 border-l-2 border-amber-300"
-                        : "bg-emerald-50 border-l-2 border-emerald-300"
-                      : ""
-                  }`}
-                >
-                  <dt className="text-gray-600 font-medium">{label}</dt>
-                  <dd className="text-gray-800 text-right break-words">
-                    {formatAuditFieldValue(data?.[key], key)}
-                    {diffs[key] && (
-                      <span
-                        className={`ml-1 inline-flex items-center text-[9px] font-semibold uppercase ${
-                          isOriginal ? "text-amber-700" : "text-emerald-700"
-                        }`}
-                      >
-                        {isOriginal ? "Prev" : "New"}
-                      </span>
-                    )}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-        </div>
+    const logsForReport = filteredLogs.map((row, index) => {
+      const diffs = getAuditFieldDiffs(row.originalData, row.newData);
+      const changes = AUDIT_FIELDS.filter(({ key }) => diffs[key]).map(
+        ({ key, label }) => ({
+          label,
+          previous: formatAuditFieldValue(row.originalData?.[key], key),
+          next: formatAuditFieldValue(row.newData?.[key], key),
+        })
       );
-    };
 
-    const entriesLabel = filteredLogs.length === 1 ? "entry" : "entries";
-
-    const sectionContent = (
-      <table className="w-full text-xs border border-gray-200">
-        <thead className="bg-gray-100">
-          <tr className="text-left text-gray-700">
-            <th className="p-2 font-semibold">Timestamp</th>
-            <th className="p-2 font-semibold">Action</th>
-            <th className="p-2 font-semibold">User</th>
-            <th className="p-2 font-semibold">Collection</th>
-            <th className="p-2 font-semibold">Transaction ID</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200 bg-white">
-          {filteredLogs.map((row) => {
-            const key =
-              row._id || row.recordId || row.transactionId || row.timestamp;
-            const diffs = getAuditFieldDiffs(row.originalData, row.newData);
-            const changedLabels = AUDIT_FIELDS.filter(
-              ({ key }) => diffs[key]
-            ).map(({ label }) => label);
-            return (
-              <React.Fragment key={key}>
-                <tr className="align-top">
-                  <td className="p-2 text-gray-800 align-top">
-                    {formatDateTime(row.timestamp)}
-                  </td>
-                  <td className="p-2 align-top">
-                    <span
-                      className={`inline-flex px-2 py-1 rounded-full font-semibold text-[11px] ${actionBadgeClass(
-                        row.action
-                      )}`}
-                    >
-                      {row.action || "—"}
-                    </span>
-                  </td>
-                  <td className="p-2 text-gray-800 align-top">
-                    {row.user || "—"}
-                  </td>
-                  <td className="p-2 text-gray-800 align-top">
-                    {row.collection || "—"}
-                  </td>
-                  <td className="p-2 text-gray-800 align-top">
-                    <code className="px-1.5 py-0.5 bg-gray-100 rounded">
-                      {row.transactionId || row.recordId || "—"}
-                    </code>
-                  </td>
-                </tr>
-                <tr>
-                  <td colSpan={5} className="p-0 bg-gray-50">
-                    <div className="p-3 border-t border-gray-200 space-y-2">
-                      <p className="text-[11px] font-semibold text-gray-600 uppercase tracking-wide">
-                        Detailed Changes
-                      </p>
-                      <div className="flex flex-wrap gap-1 text-[10px] text-gray-600">
-                        <span className="font-semibold uppercase tracking-wide text-gray-500">
-                          Fields:
-                        </span>
-                        {changedLabels.length ? (
-                          changedLabels.map((label) => (
-                            <span
-                              key={label}
-                              className="inline-flex items-center px-2 py-0.5 bg-amber-100 text-amber-700 rounded-full"
-                            >
-                              {label}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="italic text-gray-500">
-                            No differences detected
-                          </span>
-                        )}
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        {renderChangeColumn(
-                          row.originalData,
-                          "original",
-                          diffs
-                        )}
-                        {renderChangeColumn(row.newData, "updated", diffs)}
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </React.Fragment>
-            );
-          })}
-        </tbody>
-      </table>
-    );
+      return {
+        id:
+          row._id ||
+          row.recordId ||
+          row.transactionId ||
+          `${row.timestamp || "audit"}-${index}`,
+        timestamp: formatDateTime(row.timestamp),
+        action: row.action || "—",
+        user: row.user || "—",
+        collection: row.collection || "—",
+        transactionId: row.transactionId || row.recordId || "—",
+        changes,
+      };
+    });
 
     return {
-      createdAt: generatedAt.toISOString(),
-      orderNumber: `AUD-${generatedAt
+      reportNumber: `AUD-${generatedAt
         .toISOString()
         .slice(0, 10)
         .replace(/-/g, "")}`,
-      customer: { name: "Finance Department" },
-      shippingAddress: {
-        addressLine1: "Audit Log Report",
-        city: "Smart Farm System",
-      },
-      orderItems: [],
-      totalPrice: 0,
-      discount: { amount: 0 },
-      templateOptions: {
-        showBillingDetails: false,
-        showOrderSummary: true,
-        showFooter: false,
-        showItemsTable: false,
-      },
-      summaryLines,
-      customSections: [
-        {
-          title: "Audit Activity Details",
-          description: `Showing ${filteredLogs.length} ${entriesLabel} for ${filterDateLabel} (${transactionFilterLabel}).`,
-          content: sectionContent,
-        },
-      ],
+      generatedAt,
+      filterDateLabel,
+      transactionFilterLabel,
+      totalRecords: filteredLogs.length,
+      collectionsImpacted,
+      uniqueUsers,
+      actionSummary: Object.entries(actionCounts).map(
+        ([action, count]) => `${action}: ${count}`
+      ),
+      totalFieldChanges,
+      averageFieldChanges,
+      latestActivity: latestTimestamp ? new Date(latestTimestamp) : null,
+      logs: logsForReport,
     };
   }, [filteredLogs, filters]);
 
@@ -858,7 +670,9 @@ export default function AuditLogPage() {
         </div>
       </div>
       <div style={{ position: "absolute", left: "-9999px", top: 0 }}>
-        {pdfOrder && <InvoiceTemplate ref={pdfRef} order={pdfOrder} />}
+        {pdfReportData && (
+          <AuditLogPdfTemplate ref={pdfRef} data={pdfReportData} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/admin/FinanceTransaction.jsx
+++ b/frontend/src/admin/FinanceTransaction.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../lib/api";
-import { useReactToPrint } from "react-to-print";
-import { InvoiceTemplate } from "../components/common/InvoiceTemplate";
+import { TransactionPdfTemplate } from "../components/reports/TransactionPdfTemplate";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 
@@ -17,6 +16,31 @@ function currency(n) {
 
 function monthKey(iso) {
   return (iso || "").slice(0, 7);
+}
+
+function formatMonthLabel(monthValue) {
+  if (!monthValue || monthValue === "all") return "All Months";
+  const [year, month] = monthValue.split("-");
+  const y = Number(year);
+  const m = Number(month) - 1;
+  if (!Number.isNaN(y) && !Number.isNaN(m)) {
+    const date = new Date(y, m, 1);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString("en-LK", { month: "long", year: "numeric" });
+    }
+  }
+  return monthValue;
+}
+
+function formatTypeLabel(typeValue) {
+  switch (typeValue) {
+    case "INCOME":
+      return "Income Only";
+    case "EXPENSE":
+      return "Expenses Only";
+    default:
+      return "All Types";
+  }
 }
 
 function escapeHtml(text) {
@@ -124,7 +148,7 @@ export default function FinanceTransaction() {
   const [showDeleteModal, setShowDeleteModal] = useState(null); // stores mongoId or txnId
 
   const navigate = useNavigate();
-  const invoiceRef = useRef(null);
+  const pdfRef = useRef(null);
 
   useEffect(() => {
     let ignore = false;
@@ -209,70 +233,65 @@ export default function FinanceTransaction() {
     return `Transaction-${year}-${month}`;
   }, [exportDate]);
 
-  const pdfOrder = useMemo(() => {
+  const pdfReportData = useMemo(() => {
     if (!filtered.length) return null;
 
-    const items = filtered.map((txn) => {
-      const amountRaw = Number(txn.amount) || 0;
-      const amount =
-        txn.type === "EXPENSE" ? -Math.abs(amountRaw) : Math.abs(amountRaw);
+    let incomeTotal = 0;
+    let expenseTotal = 0;
+
+    const transactionsForReport = filtered.map((txn, index) => {
+      const rawAmount = Number(txn.amount) || 0;
+      if (txn.type === "INCOME") {
+        incomeTotal += Math.abs(rawAmount);
+      } else if (txn.type === "EXPENSE") {
+        expenseTotal += Math.abs(rawAmount);
+      }
+
+      const signedAmount =
+        txn.type === "EXPENSE" ? -Math.abs(rawAmount) : Math.abs(rawAmount);
+
       return {
-        name: `${shortDate(txn.date)} • ${txn.type || "Transaction"} • ${
-          txn.category || "General"
-        }`,
-        qty: 1,
-        price: amount,
+        id:
+          resolveRowId(txn) ||
+          txn.transaction_id ||
+          `txn-${index}-${shortDate(txn.date)}`,
+        date: shortDate(txn.date),
+        type: txn.type || "—",
+        category: txn.category || "—",
+        description: txn.description || "—",
+        signedAmount,
       };
     });
 
-    const totalPrice = items.reduce(
-      (sum, item) => sum + item.price * (item.qty || 1),
-      0
-    );
+    const netTotal = incomeTotal - expenseTotal;
+    const trimmedSearch = q.trim();
 
     return {
-      orderNumber: exportFileBase,
-      createdAt: exportDate,
-      status: "Approved",
-      paymentMethod: "Transactions",
-      customer: {
-        name: "Smart Farm Finance",
-        email: "finance@smartfarm.local",
+      reportNumber: exportFileBase,
+      generatedAt: new Date(),
+      reportingPeriod: formatMonthLabel(monthFilter),
+      typeFilterLabel: formatTypeLabel(typeFilter),
+      searchQuery: trimmedSearch,
+      totalRecords: transactionsForReport.length,
+      totals: {
+        income: incomeTotal,
+        expense: expenseTotal,
+        net: netTotal,
       },
-      shippingAddress: {
-        addressLine1: "Transaction Summary Report",
-        city: "",
-        postalCode: "",
-      },
-      orderItems: items,
-      totalPrice,
-      discount: { amount: 0 },
-      templateOptions: {
-        showBillingDetails: false,
-        showOrderSummary: false,
-        showFooter: false,
-      },
+      transactions: transactionsForReport,
     };
-  }, [filtered, exportDate, exportFileBase]);
-
-  const triggerPrint = useReactToPrint({
-    contentRef: invoiceRef,
-    documentTitle: exportFileBase,
-    removeAfterPrint: true,
-    suppressErrors: true,
-  });
+  }, [filtered, exportFileBase, monthFilter, typeFilter, q]);
 
   const handleExportPdf = async () => {
-    if (!filtered.length || !pdfOrder) {
+    if (!filtered.length || !pdfReportData) {
       alert("No transactions to export.");
       return;
     }
 
-    // Use invoiceRef to render the InvoiceTemplate
-    const input = invoiceRef.current;
+    const input = pdfRef.current;
 
     if (!input) {
-      alert("Invoice not ready.");
+      alert("Report not ready.");
       return;
     }
 
@@ -282,7 +301,6 @@ export default function FinanceTransaction() {
       const pdf = new jsPDF("p", "mm", "a4");
 
       const pageWidth = pdf.internal.pageSize.getWidth();
-      const pageHeight = pdf.internal.pageSize.getHeight();
       const imgProps = pdf.getImageProperties(imgData);
       const imgHeight = (imgProps.height * pageWidth) / imgProps.width;
 
@@ -776,69 +794,9 @@ export default function FinanceTransaction() {
         </div>
       </div>
       <div style={{ position: "absolute", left: "-9999px", top: 0 }}>
-        {pdfOrder && (
-          <div
-            ref={invoiceRef}
-            style={{
-              fontFamily: "sans-serif",
-              fontSize: "12px",
-              color: "#374151",
-            }}
-          >
-            {/* Header */}
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "flex-start",
-                borderBottom: "2px solid #059669",
-                paddingBottom: "12px",
-                marginBottom: "16px",
-              }}
-            >
-              {/* Left Side - Farm Info */}
-              <div>
-                <h1
-                  style={{
-                    fontSize: "24px",
-                    fontWeight: "bold",
-                    color: "#059669",
-                    margin: 0,
-                  }}
-                >
-                  GreenLeaf Farm
-                </h1>
-                <p style={{ margin: "2px 0" }}>
-                  10/F, Ginimellagaha, Baddegama, Sri Lanka
-                </p>
-                <p style={{ margin: "2px 0" }}>
-                  contact@greenleaffarm.com | +94 11 234 5678
-                </p>
-              </div>
-
-              {/* Right Side - Report Info */}
-              <div style={{ textAlign: "right" }}>
-                <h2
-                  style={{
-                    fontSize: "20px",
-                    fontWeight: "bold",
-                    color: "#4B5563",
-                    margin: 0,
-                  }}
-                >
-                  REPORT
-                </h2>
-                <p style={{ margin: "2px 0" }}>Report #: {exportFileBase}</p>
-                <p style={{ margin: "2px 0" }}>
-                  Date: {new Date(exportDate).toLocaleDateString()}
-                </p>
-              </div>
-            </div>
-
-            {/* Reuse invoice template without its own header */}
-            <InvoiceTemplate order={pdfOrder} hideHeader />
-          </div>
-        )}
+        {pdfReportData ? (
+          <TransactionPdfTemplate ref={pdfRef} data={pdfReportData} />
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/components/reports/AuditLogPdfTemplate.jsx
+++ b/frontend/src/components/reports/AuditLogPdfTemplate.jsx
@@ -1,0 +1,377 @@
+import React, { forwardRef } from "react";
+import {
+  BRAND_CONTACT_LINE,
+  BRAND_DETAILS,
+  BRAND_DOCUMENT_TITLES,
+} from "../../constants/branding";
+
+const sectionTitleStyle = {
+  margin: "0 0 12px",
+  fontSize: "16px",
+  fontWeight: 600,
+  color: "#047857",
+};
+
+const labelStyle = {
+  fontSize: "11px",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "#6b7280",
+};
+
+const valueStyle = {
+  fontSize: "15px",
+  fontWeight: 600,
+  color: "#111827",
+};
+
+const summaryCardStyle = {
+  flex: "1 1 160px",
+  minWidth: "160px",
+  backgroundColor: "#f9fafb",
+  border: "1px solid #e5e7eb",
+  borderRadius: "12px",
+  padding: "12px 16px",
+};
+
+const getActionStyles = (action) => {
+  switch (action) {
+    case "ADD":
+      return { backgroundColor: "#dcfce7", color: "#047857" };
+    case "UPDATE":
+      return { backgroundColor: "#fef3c7", color: "#b45309" };
+    case "DELETE":
+    case "REMOVE":
+      return { backgroundColor: "#fee2e2", color: "#b91c1c" };
+    default:
+      return { backgroundColor: "#e5e7eb", color: "#374151" };
+  }
+};
+
+export const AuditLogPdfTemplate = forwardRef(function AuditLogPdfTemplate(
+  { data },
+  ref
+) {
+  if (!data) return null;
+
+  const {
+    reportNumber,
+    generatedAt,
+    filterDateLabel,
+    transactionFilterLabel,
+    totalRecords,
+    collectionsImpacted,
+    uniqueUsers,
+    actionSummary,
+    totalFieldChanges,
+    averageFieldChanges,
+    latestActivity,
+    logs,
+  } = data;
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+        color: "#1f2937",
+        backgroundColor: "#ffffff",
+        padding: "36px",
+        width: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: "16px",
+          paddingBottom: "16px",
+          borderBottom: "2px solid #10b981",
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: "26px",
+              fontWeight: 700,
+              color: "#047857",
+            }}
+          >
+            {BRAND_DETAILS.name}
+          </h1>
+          <p style={{ margin: "4px 0", fontSize: "12px", color: "#4b5563" }}>
+            {BRAND_DETAILS.address}
+          </p>
+          <p style={{ margin: "0", fontSize: "12px", color: "#4b5563" }}>
+            {BRAND_CONTACT_LINE}
+          </p>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "20px",
+              fontWeight: 600,
+              letterSpacing: "0.08em",
+              color: "#4b5563",
+            }}
+          >
+            {BRAND_DOCUMENT_TITLES.report}
+          </h2>
+          <p style={{ margin: "4px 0", fontSize: "12px", color: "#374151" }}>
+            Report #: {reportNumber || "—"}
+          </p>
+          <p style={{ margin: 0, fontSize: "12px", color: "#374151" }}>
+            Generated: {new Date(generatedAt).toLocaleString("en-LK", {
+              year: "numeric",
+              month: "long",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </p>
+        </div>
+      </header>
+
+      <section style={{ marginTop: "24px" }}>
+        <h3 style={sectionTitleStyle}>Report Summary</h3>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Date Filter</div>
+            <div style={valueStyle}>{filterDateLabel}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Transaction Filter</div>
+            <div style={{ ...valueStyle, fontSize: "13px" }}>
+              {transactionFilterLabel}
+            </div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Total Records</div>
+            <div style={valueStyle}>{totalRecords}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Collections Impacted</div>
+            <div style={{ ...valueStyle, fontSize: "13px" }}>
+              {collectionsImpacted.length
+                ? collectionsImpacted.join(", ")
+                : "—"}
+            </div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Users Involved</div>
+            <div style={{ ...valueStyle, fontSize: "13px" }}>
+              {uniqueUsers.length ? uniqueUsers.join(", ") : "—"}
+            </div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Action Breakdown</div>
+            <div style={{ ...valueStyle, fontSize: "12px", lineHeight: 1.4 }}>
+              {actionSummary.length ? actionSummary.join(" | ") : "—"}
+            </div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Total Field Changes</div>
+            <div style={valueStyle}>{totalFieldChanges}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Avg. Fields / Record</div>
+            <div style={valueStyle}>{averageFieldChanges}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={labelStyle}>Latest Activity</div>
+            <div style={{ ...valueStyle, fontSize: "13px" }}>
+              {latestActivity
+                ? new Date(latestActivity).toLocaleString("en-LK", {
+                    year: "numeric",
+                    month: "long",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })
+                : "—"}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ marginTop: "32px" }}>
+        <h3 style={sectionTitleStyle}>Audit Entries</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          {logs.map((log) => {
+            const actionStyles = getActionStyles(log.action);
+            return (
+              <div
+                key={log.id}
+                style={{
+                  border: "1px solid #d1d5db",
+                  borderRadius: "12px",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: "12px",
+                    backgroundColor: "#f9fafb",
+                    padding: "12px 16px",
+                    borderBottom: "1px solid #e5e7eb",
+                  }}
+                >
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: "12px", color: "#4b5563" }}>
+                      {log.timestamp}
+                    </div>
+                    <div style={{ fontSize: "13px", color: "#111827" }}>
+                      Collection: <strong>{log.collection}</strong>
+                    </div>
+                    <div style={{ fontSize: "12px", color: "#4b5563" }}>
+                      Transaction ID: <code>{log.transactionId}</code>
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      alignSelf: "flex-start",
+                      padding: "6px 12px",
+                      borderRadius: "999px",
+                      fontSize: "11px",
+                      fontWeight: 600,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.05em",
+                      backgroundColor: actionStyles.backgroundColor,
+                      color: actionStyles.color,
+                    }}
+                  >
+                    {log.action}
+                  </div>
+                  <div style={{ textAlign: "right" }}>
+                    <div style={{ fontSize: "12px", color: "#4b5563" }}>
+                      User
+                    </div>
+                    <div style={{ fontSize: "13px", fontWeight: 600 }}>
+                      {log.user}
+                    </div>
+                  </div>
+                </div>
+
+                <div style={{ padding: "16px" }}>
+                  <div style={{ ...labelStyle, marginBottom: "8px" }}>
+                    Field Changes
+                  </div>
+                  {log.changes.length ? (
+                    <table
+                      style={{
+                        width: "100%",
+                        borderCollapse: "collapse",
+                        fontSize: "12px",
+                      }}
+                    >
+                      <thead>
+                        <tr>
+                          <th
+                            style={{
+                              textAlign: "left",
+                              padding: "8px 10px",
+                              backgroundColor: "#ecfdf5",
+                              borderBottom: "1px solid #d1d5db",
+                              fontWeight: 600,
+                              color: "#047857",
+                            }}
+                          >
+                            Field
+                          </th>
+                          <th
+                            style={{
+                              textAlign: "left",
+                              padding: "8px 10px",
+                              backgroundColor: "#f9fafb",
+                              borderBottom: "1px solid #d1d5db",
+                              fontWeight: 600,
+                              color: "#6b7280",
+                            }}
+                          >
+                            Previous
+                          </th>
+                          <th
+                            style={{
+                              textAlign: "left",
+                              padding: "8px 10px",
+                              backgroundColor: "#f9fafb",
+                              borderBottom: "1px solid #d1d5db",
+                              fontWeight: 600,
+                              color: "#6b7280",
+                            }}
+                          >
+                            Updated
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {log.changes.map((change) => (
+                          <tr key={change.label}>
+                            <td
+                              style={{
+                                padding: "8px 10px",
+                                borderBottom: "1px solid #e5e7eb",
+                                fontWeight: 600,
+                                color: "#047857",
+                              }}
+                            >
+                              {change.label}
+                            </td>
+                            <td
+                              style={{
+                                padding: "8px 10px",
+                                borderBottom: "1px solid #e5e7eb",
+                                color: "#b45309",
+                              }}
+                            >
+                              {change.previous}
+                            </td>
+                            <td
+                              style={{
+                                padding: "8px 10px",
+                                borderBottom: "1px solid #e5e7eb",
+                                color: "#047857",
+                              }}
+                            >
+                              {change.next}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  ) : (
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                        fontStyle: "italic",
+                      }}
+                    >
+                      No field differences detected for this entry.
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <footer
+        style={{
+          marginTop: "36px",
+          fontSize: "10px",
+          color: "#6b7280",
+          textAlign: "center",
+        }}
+      >
+        Generated for compliance tracking. Please store this report securely.
+      </footer>
+    </div>
+  );
+});

--- a/frontend/src/components/reports/TransactionPdfTemplate.jsx
+++ b/frontend/src/components/reports/TransactionPdfTemplate.jsx
@@ -1,0 +1,326 @@
+import React, { forwardRef } from "react";
+import {
+  BRAND_CONTACT_LINE,
+  BRAND_DETAILS,
+  BRAND_DOCUMENT_TITLES,
+} from "../../constants/branding";
+
+const cardContainerStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "12px",
+  marginTop: "16px",
+};
+
+const summaryCardStyle = {
+  flex: "1 1 160px",
+  backgroundColor: "#f9fafb",
+  border: "1px solid #e5e7eb",
+  borderRadius: "12px",
+  padding: "12px 16px",
+  minWidth: "160px",
+};
+
+const cardLabelStyle = {
+  fontSize: "11px",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "#6b7280",
+  marginBottom: "4px",
+};
+
+const cardValueStyle = {
+  fontSize: "16px",
+  fontWeight: 600,
+  color: "#111827",
+};
+
+const tableHeaderCellStyle = {
+  padding: "10px 12px",
+  textAlign: "left",
+  fontSize: "11px",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  color: "#6b7280",
+  borderBottom: "2px solid #10b981",
+  backgroundColor: "#ecfdf5",
+};
+
+const tableCellStyle = {
+  padding: "10px 12px",
+  fontSize: "12px",
+  borderBottom: "1px solid #e5e7eb",
+  verticalAlign: "top",
+};
+
+const amountCellStyle = {
+  ...tableCellStyle,
+  textAlign: "right",
+  fontWeight: 600,
+};
+
+const totalsRowLabelStyle = {
+  textAlign: "right",
+  fontSize: "13px",
+  fontWeight: 600,
+  padding: "10px 12px",
+  borderTop: "2px solid #e5e7eb",
+};
+
+const totalsRowValueStyle = {
+  ...totalsRowLabelStyle,
+  textAlign: "right",
+  color: "#111827",
+};
+
+const formatCurrency = (amount) => {
+  const value = Number(amount) || 0;
+  return value.toLocaleString("en-LK", {
+    style: "currency",
+    currency: "LKR",
+    minimumFractionDigits: 2,
+  });
+};
+
+const formatDateTime = (value) => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("en-LK", {
+    year: "numeric",
+    month: "long",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+export const TransactionPdfTemplate = forwardRef(function TransactionPdfTemplate(
+  { data },
+  ref
+) {
+  if (!data) return null;
+
+  const {
+    reportNumber,
+    generatedAt,
+    reportingPeriod,
+    typeFilterLabel,
+    searchQuery,
+    totalRecords,
+    totals,
+    transactions,
+  } = data;
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+        color: "#1f2937",
+        backgroundColor: "#ffffff",
+        padding: "36px",
+        width: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: "16px",
+          paddingBottom: "16px",
+          borderBottom: "2px solid #10b981",
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: "26px",
+              fontWeight: 700,
+              color: "#047857",
+            }}
+          >
+            {BRAND_DETAILS.name}
+          </h1>
+          <p style={{ margin: "4px 0", fontSize: "12px", color: "#4b5563" }}>
+            {BRAND_DETAILS.address}
+          </p>
+          <p style={{ margin: "0", fontSize: "12px", color: "#4b5563" }}>
+            {BRAND_CONTACT_LINE}
+          </p>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "20px",
+              fontWeight: 600,
+              letterSpacing: "0.08em",
+              color: "#4b5563",
+            }}
+          >
+            {BRAND_DOCUMENT_TITLES.report}
+          </h2>
+          <p style={{ margin: "4px 0", fontSize: "12px", color: "#374151" }}>
+            Report #: {reportNumber || "—"}
+          </p>
+          <p style={{ margin: 0, fontSize: "12px", color: "#374151" }}>
+            Generated: {formatDateTime(generatedAt)}
+          </p>
+        </div>
+      </header>
+
+      <section style={{ marginTop: "24px" }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "#047857",
+          }}
+        >
+          Report Overview
+        </h3>
+        <div style={cardContainerStyle}>
+          <div style={summaryCardStyle}>
+            <div style={cardLabelStyle}>Reporting Period</div>
+            <div style={cardValueStyle}>{reportingPeriod || "All"}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={cardLabelStyle}>Transaction Type</div>
+            <div style={cardValueStyle}>{typeFilterLabel || "All"}</div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={cardLabelStyle}>Total Records</div>
+            <div style={cardValueStyle}>{totalRecords}</div>
+          </div>
+          {searchQuery ? (
+            <div style={summaryCardStyle}>
+              <div style={cardLabelStyle}>Search Filter</div>
+              <div style={{ ...cardValueStyle, fontSize: "13px" }}>
+                {searchQuery}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section style={{ marginTop: "24px" }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "#047857",
+          }}
+        >
+          Financial Summary
+        </h3>
+        <div style={cardContainerStyle}>
+          <div style={{ ...summaryCardStyle, backgroundColor: "#ecfdf5" }}>
+            <div style={cardLabelStyle}>Total Income</div>
+            <div style={{ ...cardValueStyle, color: "#047857" }}>
+              {formatCurrency(totals.income)}
+            </div>
+          </div>
+          <div style={{ ...summaryCardStyle, backgroundColor: "#fef2f2" }}>
+            <div style={cardLabelStyle}>Total Expenses</div>
+            <div style={{ ...cardValueStyle, color: "#b91c1c" }}>
+              {formatCurrency(totals.expense)}
+            </div>
+          </div>
+          <div style={summaryCardStyle}>
+            <div style={cardLabelStyle}>Net Total</div>
+            <div
+              style={{
+                ...cardValueStyle,
+                color: totals.net >= 0 ? "#047857" : "#b91c1c",
+              }}
+            >
+              {formatCurrency(totals.net)}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ marginTop: "32px" }}>
+        <h3
+          style={{
+            marginBottom: "12px",
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "#047857",
+          }}
+        >
+          Transaction Details
+        </h3>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={tableHeaderCellStyle}>Transaction ID</th>
+              <th style={tableHeaderCellStyle}>Date</th>
+              <th style={tableHeaderCellStyle}>Type</th>
+              <th style={tableHeaderCellStyle}>Category</th>
+              <th style={tableHeaderCellStyle}>Description</th>
+              <th style={{ ...tableHeaderCellStyle, textAlign: "right" }}>
+                Amount (LKR)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((txn) => {
+              const amountIsNegative = txn.signedAmount < 0;
+              return (
+                <tr key={txn.id}>
+                  <td style={{ ...tableCellStyle, fontFamily: "monospace" }}>
+                    {txn.id}
+                  </td>
+                  <td style={tableCellStyle}>{txn.date}</td>
+                  <td style={tableCellStyle}>{txn.type}</td>
+                  <td style={tableCellStyle}>{txn.category}</td>
+                  <td style={tableCellStyle}>{txn.description}</td>
+                  <td
+                    style={{
+                      ...amountCellStyle,
+                      color: amountIsNegative ? "#b91c1c" : "#047857",
+                    }}
+                  >
+                    {formatCurrency(txn.signedAmount)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={5} style={totalsRowLabelStyle}>
+                Net Total
+              </td>
+              <td
+                style={{
+                  ...totalsRowValueStyle,
+                  color: totals.net >= 0 ? "#047857" : "#b91c1c",
+                }}
+              >
+                {formatCurrency(totals.net)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </section>
+
+      <footer
+        style={{
+          marginTop: "36px",
+          fontSize: "10px",
+          color: "#6b7280",
+          textAlign: "center",
+        }}
+      >
+        Generated by Smart Farm Finance Suite. This document is automatically
+        created for record keeping purposes.
+      </footer>
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary
- add tailored PDF templates for transaction and audit log exports with branded layouts and summaries
- update finance transaction export flow to build report metadata and render the new template
- update finance audit log export flow to prepare detailed change data for the audit PDF template

## Testing
- npm run lint *(fails: pre-existing lint errors throughout frontend, see run for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e720254483219b0644f400f8ecdb