### PR TITLE
Allow employees to access both dashboards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -89,11 +89,10 @@ const CustomersPage = () => (
 const Private = ({ children }) =>
   auth.token ? children : <Navigate to="/login" replace />;
 
-const AdminOnly = ({ children }) =>
-  auth.user?.role === "Admin" ? children : <Navigate to="/" replace />;
-
-const EmployeeOnly = ({ children }) =>
-  auth.user?.role === "Employee" ? children : <Navigate to="/" replace />;
+const AdminOrEmployee = ({ children }) =>
+  auth.user?.role === "Admin" || auth.user?.role === "Employee"
+    ? children
+    : <Navigate to="/" replace />;
 
 export default function App() {
   return (
@@ -142,9 +141,9 @@ export default function App() {
       <Route
         path="/dashboard"
         element={
-          <EmployeeOnly>
+          <AdminOrEmployee>
             <EmployeeDashboard />
-          </EmployeeOnly>
+          </AdminOrEmployee>
         }
       />
 
@@ -152,7 +151,7 @@ export default function App() {
       <Route
         path="/admin"
         element={
-          <AdminOnly>
+          <AdminOrEmployee>
             <Suspense
               fallback={
                 <div className="w-full h-screen flex items-center justify-center text-lg">
@@ -162,7 +161,7 @@ export default function App() {
             >
               <AdminLayout />
             </Suspense>
-          </AdminOnly>
+          </AdminOrEmployee>
         }
       >
         <Route index element={<MainDashboard />} />

--- a/frontend/src/admin/Sidebar.jsx
+++ b/frontend/src/admin/Sidebar.jsx
@@ -129,6 +129,13 @@ const SidebarInner = ({ location, navigate, closeMobile }) => {
         >
           Dashboard
         </SidebarLink>
+        <SidebarLink
+          to="/dashboard"
+          icon="fas fa-briefcase"
+          onNavigate={onNavigate}
+        >
+          Employee Dashboard
+        </SidebarLink>
 
         {/* Farm */}
         <SectionLabel>Farm</SectionLabel>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -183,10 +183,8 @@ export default function LoginPage() {
       login({ token: data.token, user: data.user });
       const userRole = data?.user?.role;
 
-      if (userRole === "Admin") {
+      if (userRole === "Admin" || userRole === "Employee") {
         navigate("/admin", { replace: true });
-      } else if (userRole === "Employee") {
-        navigate("/dashboard", { replace: true });
       } else {
         navigate("/", { replace: true });
       }


### PR DESCRIPTION
## Summary
- allow both admin and employee roles to pass the protected routes for the admin and employee dashboards
- redirect employees to the admin dashboard immediately after login
- add an employee dashboard navigation shortcut to the admin sidebar

## Testing
- `npm run lint` *(fails: existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e36f8289b083218795928bda830d18